### PR TITLE
fix status without mount and quest

### DIFF
--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -176,7 +176,7 @@ class Status(ApplicationWithApi):
         user['pet'] = user['items']['currentPet']
         user['pet'] = content['petInfo'][user['pet']]['text'] if user['pet'] else ''
         user['pet'] = _("Pet: ") + user['pet'] if user['pet'] else _("No pet")  # noqa: Q000
-        user['mount'] = user['items']['currentMount']
+        user['mount'] = user['items'].get('currentMount', None)
         user['mount'] = content['mountInfo'][user['mount']]['text'] if user['mount'] else ''
         if user['mount']:
             user['mount'] = _("Mount: ") + user['mount']  # noqa: Q000
@@ -201,7 +201,7 @@ class Status(ApplicationWithApi):
 
     def quest_info(self, user):
         'Get current quest info or return None'
-        key = user['party']['quest']['key']
+        key = user['party']['quest'].get('key', None)
         if '_id' not in user['party'] or key is None:
             return
         for refresh in False, True:


### PR DESCRIPTION
without this fix I would get
```
habitipy status
Traceback (most recent call last):
  File "/usr/local/bin/habitipy", line 11, in <module>
    load_entry_point('habitipy', 'console_scripts', 'habitipy')()
  File "/usr/local/lib/python3.5/dist-packages/plumbum/cli/application.py", line 138, in __new__
    return cls.run()
  File "/usr/local/lib/python3.5/dist-packages/plumbum/cli/application.py", line 509, in run
    inst, retcode = subapp.run(argv, exit = False)
  File "/usr/local/lib/python3.5/dist-packages/plumbum/cli/application.py", line 504, in run
    retcode = inst.main(*tailargs)
  File "/home/.../habitipy/habitipy/cli.py", line 179, in main
    user['mount'] = user['items']['currentMount']
KeyError: 'currentMount'
```