### PR TITLE
Fix spells command

### DIFF
--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -678,6 +678,7 @@ class Spells(ApplicationWithApi):
     def main(self):
         if self.nested_command:
             return
+        super().main()
         user = self.api.user.get()
         content = get_content(self.api)
         user_level = user['stats']['lvl']


### PR DESCRIPTION
This should fix the following error:
```
$ habitipy spells
Traceback (most recent call last):
  File "/home/robert/.local/bin/habitipy", line 11, in <module>
    sys.exit(HabiticaCli())
  File "/home/robert/.local/lib/python3.5/site-packages/plumbum/cli/application.py", line 136, in __new__
    return cls.run()
  File "/home/robert/.local/lib/python3.5/site-packages/plumbum/cli/application.py", line 505, in run
    inst, retcode = subapp.run(argv, exit = False)
  File "/home/robert/.local/lib/python3.5/site-packages/plumbum/cli/application.py", line 500, in run
    retcode = inst.main(*tailargs)
  File "/home/robert/.local/lib/python3.5/site-packages/habitipy/cli.py", line 681, in main
    user = self.api.user.get()
AttributeError: 'NoneType' object has no attribute 'user'
```