### PR TITLE
Fix parsing API parameters without type

### DIFF
--- a/habitipy/api.py
+++ b/habitipy/api.py
@@ -425,15 +425,19 @@ class Param:
         else:
             self.field = self.field[0]
             self.path = []
-        self.type = type_[1:-1] if len(type_) > 2 else type_
-        if '=' in self.type:
-            self.type, self.possible_values = self.type.split('=')
-            self.possible_values = list(map(
-                lambda s: s if s[0] != '"' else s[1:-1],
-                self.possible_values.split(',')))
+        if type_:
+            self.type = type_[1:-1] if len(type_) > 2 else type_
+            if '=' in self.type:
+                self.type, self.possible_values = self.type.split('=')
+                self.possible_values = list(map(
+                    lambda s: s if s[0] != '"' else s[1:-1],
+                    self.possible_values.split(',')))
+            else:
+                self.possible_values = []
+            self.type = self.type.lower()
         else:
+            self.type = None
             self.possible_values = []
-        self.type = self.type.lower()
         self.description = description
 
     def validate(self, obj):
@@ -451,6 +455,6 @@ class Param:
         opt = 'optional' if self.is_optional else ''
         can_be = ' '.join(self.possible_values) if self.possible_values else ''
         can_be = 'one of [{}]'.format(can_be) if can_be else ''
-        type_ = 'of type "' + self.type + '"'
+        type_ = 'of type "' + str(self.type) + '"'
         res = ' '.join([opt, '"' + self.field + '"', default, type_, can_be, '\n'])
         return res.replace('  ', ' ').lstrip()

--- a/habitipy/api.py
+++ b/habitipy/api.py
@@ -166,7 +166,7 @@ class Habitipy:
     ```
     """
     def __init__(self, conf: Dict[str, str], *,
-                 apis=None, current: Optional[List[str]]=None,
+                 apis=None, current: Optional[List[str]] = None,
                  from_github=False, branch=None,
                  strict=False) -> None:
         self._conf = conf

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -196,8 +196,10 @@ class Status(ApplicationWithApi):
             colors.yellow | _("XP: {stats[exp]}/{stats[toNextLevel]}"),  # noqa: Q000
             colors.blue | _("Mana: {stats[mp]}/{stats[maxMP]}"),  # noqa: Q000
             colors.light_yellow | _("GP: {stats[gp]:.2f}"),  # noqa: Q000
-            '{pet} ' +
-            ngettext("({food} food item)", "({food} food items)", user['food']),  # noqa: Q000
+            '{pet} ' + ngettext(
+                "({food} food item)",   # noqa: Q000
+                "({food} food items)",  # noqa: Q000
+                user['food']),
             '{mount}']
         quest = self.quest_info(user)
         if quest:

--- a/habitipy/util.py
+++ b/habitipy/util.py
@@ -164,7 +164,7 @@ def get_translation_for(package_name: str) -> gettext.NullTranslations:
     return gettext.translation(package_name, localedir=localedir, fallback=True)  # type: ignore
 
 
-def get_translation_functions(package_name: str, names: Tuple[str, ...]=('gettext',)):
+def get_translation_functions(package_name: str, names: Tuple[str, ...] = ('gettext',)):
     """finds and installs translation functions for package"""
     translation = get_translation_for(package_name)
     return [getattr(translation, x) for x in names]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,7 @@ test_data = """
 @apiSuccess {Object} data.options The options for the webhook (See webhook add examples)
 @api {delete} /api/v3/user/webhook/:id Delete a webhook - BETA
 @apiParam (Path) {UUID} id The id of the webhook to delete
+@apiParam (Query) [dueDate] type Optional date to use for computing the nextDue field for each returned task.
 """
 wrong_apidoc_data = [
 """@api {delete} /api/v3/user/webhook/:id Delete a webhook - BETA


### PR DESCRIPTION
If there is no specific type specified for an `@apiParam`, the parsing fails because it tries to find '=' within the type variable and if it is `None`, it can't iterate to find the equals sign.

So whenever the `type_` group from the regex now is `None`, we just set the parsed type to `None` and also make sure we handle this properly when rendering the docstring.

In more recent versions of Habitica the following `@apiParam` was introduced, which exactly triggers this problem:

```
@apiParam (Query) [dueDate] type Optional date to use for computing the nextDue field for each returned task.
```