### PR TITLE
Allow uri param forcing

### DIFF
--- a/habitipy/api.py
+++ b/habitipy/api.py
@@ -252,6 +252,11 @@ class Habitipy:
             raise ValueError('{} is not an endpoint!'.format(uri))
         method = self._node.method
         headers = self._make_headers()
+
+        # allow a caller to force URI parameters when API document is incorrect
+        if 'uri_params'in kwargs:
+            uri += "?" + "&".join([str(x) + "=" + str(y) for x,y in kwargs['uri_params'].items()])
+
         query = {}
         if 'query' in self._node.params:
             for name, param in self._node.params['query'].items():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+setuptools
+requests
+plumbum


### PR DESCRIPTION
This may not be the best way to accomplish this, but in the case of the pet-feed operation it supports an 'amount' keyword which is oddly in the URI query parameters and not a post attribute.  So this lets me feed a pet with more than 1 food item.