### PR TITLE
Pets commands

### DIFF
--- a/habitipy/api.py
+++ b/habitipy/api.py
@@ -254,8 +254,8 @@ class Habitipy:
         headers = self._make_headers()
 
         # allow a caller to force URI parameters when API document is incorrect
-        if 'uri_params'in kwargs:
-            uri += "?" + "&".join([str(x) + "=" + str(y) for x,y in kwargs['uri_params'].items()])
+        if 'uri_params' in kwargs:
+            uri += '?' + '&'.join([str(x) + '=' + str(y) for x, y in kwargs['uri_params'].items()])
 
         query = {}
         if 'query' in self._node.params:

--- a/habitipy/api.py
+++ b/habitipy/api.py
@@ -252,6 +252,11 @@ class Habitipy:
             raise ValueError('{} is not an endpoint!'.format(uri))
         method = self._node.method
         headers = self._make_headers()
+
+        # allow a caller to force URI parameters when API document is incorrect
+        if 'uri_params'in kwargs:
+            uri += "?" + "&".join([str(x) + "=" + str(y) for x,y in kwargs['uri_params'].items()])
+
         query = {}
         if 'query' in self._node.params:
             for name, param in self._node.params['query'].items():

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -407,7 +407,7 @@ class ListPets(Pets):
     def main(self):
         super().main()
         user = self.api.user.get()
-        print("Pets:")
+        print(_("Pets:"))
 
         # split pets into type and color
         pet_summaries = defaultdict(dict)
@@ -429,11 +429,11 @@ class ListPets(Pets):
 
                 pet_full_level = pet_summaries[pet][color]
                 if pet_full_level == -1:
-                    full_percentage = "No Pet"
+                    full_percentage = colors.red | _("No Pet")
                     if self.is_hatchable(user, pet, color):
-                        full_percentage += " (hatchable)"
+                        full_percentage += " " + colors.green | _("(hatchable)")
                 elif pet + "-" + color in user['items']['mounts']:
-                    full_percentage = "100%"
+                    full_percentage = colors.green | "100%"
                 else:
                     full_percentage = self.get_full_percent(pet_full_level) + "%"
                 print(f"    {color:<30} {full_percentage}")
@@ -470,14 +470,14 @@ class FeedPet(Pets):
             food_needed = self.get_food_needed(pets[pet])
             if food_needed > 0 and pet not in mounts:
                 food_amount = min(food_needed, self.maximum_food)
-                print(f"feeding {food_amount} {food} to {color} {pettype}")
+                print(_(f"feeding {food_amount} {food} to {color} {pettype}"))
                 response = self.api.user.feed[pet][food].post(uri_params = {
                     'amount': food_amount,
                 })
-                print(f"   new fullness: {self.get_full_percent(response)}%")
+                print(_(f"   new fullness: {self.get_full_percent(response)}%"))
                 time.sleep(self.sleep_time)
             else:
-                print(f"NOT feeding {color} {pettype}")
+                print(_(f"NOT feeding {color} {pettype}"))
 
 @Pets.subcommand('hatch')
 class HatchPet(Pets):
@@ -504,11 +504,11 @@ class HatchPet(Pets):
                 continue
         
             if self.is_hatchable(user, pettype, color):
-                print(f"hatching {color} {pettype}")
+                print(_(f"hatching {color} {pettype}"))
                 response = self.api.user.hatch[pettype][color].post()
                 time.sleep(self.sleep_time)
             else:
-                print(f"NOT hatching {color} {pettype}")
+                print(_(f"NOT hatching {color} {pettype}"))
 
 
 @HabiticaCli.subcommand('food')

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -439,7 +439,7 @@ class FeedPet(ApplicationWithApi):
                 response = self.api.user.feed[pet][food].post(uri_params = {
                     'amount': food_needed
                 })
-                print(f"   response:{response}")
+                print(f"   new hunger (-1 = full):{response}")
                 time.sleep(sleep_time)
             else:
                 print(f"NOT feeding {color} {pettype}")

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -364,15 +364,16 @@ class TasksPrint(ApplicationWithApi):
             res = i + prettify(self.domain_format(task))
             print(res)
 
+
 @HabiticaCli.subcommand('pets')
 class Pets(ApplicationWithApi):
-    DESCRIPTION = _("List pets and their status")
+    DESCRIPTION = _('List pets and their status')
     pet_specifier = cli.SwitchAttr(
         ['-P', '--pet'],
-        help=_("Only show information about a particular pet"))  # noqa: Q000
+        help=_('Only show information about a particular pet'))  # noqa: Q000
     color_specifier = cli.SwitchAttr(
         ['-C', '--color'],
-        help=_("Only show information about a particular color"))  # noqa: Q000
+        help=_('Only show information about a particular color'))  # noqa: Q000
 
     def get_full_percent(self, amount: int):
         if amount == -1:
@@ -384,30 +385,29 @@ class Pets(ApplicationWithApi):
     def get_food_needed(self, pet_fullness: int, amount_per_food: int = 5) -> int:
         if pet_fullness == -1:
             return 0
-        return int((50 - int(pet_fullness))/amount_per_food)
+        return int((50 - int(pet_fullness)) / amount_per_food)
 
     def is_hatchable(self, user: list, pet: str, color: str) -> bool:
         "Return true when a pat of a particular type and color can be hatched."
-
-        combined = pet + "-" + color
+        combined = pet + '-' + color
 
         # check if pet exists or name is wrong
-        if user["items"]["pets"].get(combined, 100) != -1:
+        if user['items']['pets'].get(combined, 100) != -1:
             return False
 
-        if color not in user["items"]["hatchingPotions"] or pet not in user["items"]["eggs"]:
+        if color not in user['items']['hatchingPotions'] or pet not in user['items']['eggs']:
             return False
-        if user["items"]["hatchingPotions"][color] > 0 and user["items"]["eggs"][pet] > 0:
+        if user['items']['hatchingPotions'][color] > 0 and user['items']['eggs'][pet] > 0:
             return True
         return False
-        
+
 
 @Pets.subcommand('list')
 class ListPets(Pets):
     def main(self):
         super().main()
         user = self.api.user.get()
-        print(_("Pets:"))
+        print(_('Pets:'))
 
         color_specifier = self.color_specifier
         if color_specifier:
@@ -419,7 +419,7 @@ class ListPets(Pets):
         # split pets into type and color
         pet_summaries = defaultdict(dict)
         for pet in user['items']['pets']:
-            (pettype, color) = pet.split("-")
+            (pettype, color) = pet.split('-')
             pet_summaries[pettype][color] = user['items']['pets'][pet]
 
         for pet in pet_summaries:
@@ -431,38 +431,39 @@ class ListPets(Pets):
                     continue
 
                 if not pet_printed:
-                    print(f"  {pet}:")
+                    print(f'  {pet}:')
                     pet_printed = True
 
                 pet_full_level = pet_summaries[pet][color]
                 if pet_full_level == -1:
-                    full_percentage = colors.red | _("No Pet")
+                    full_percentage = colors.red | _('No Pet')
                     if self.is_hatchable(user, pet, color):
-                        full_percentage += " " + (colors.green | _("(hatchable)"))
-                elif pet + "-" + color in user['items']['mounts']:
-                    full_percentage = colors.green | "100%"
+                        full_percentage += ' ' + (colors.green | _('(hatchable)'))
+                elif pet + '-' + color in user['items']['mounts']:
+                    full_percentage = colors.green | '100%'
                 else:
-                    full_percentage = self.get_full_percent(pet_full_level) + "%"
-                    if full_percentage == "100%":
+                    full_percentage = self.get_full_percent(pet_full_level) + '%'
+                    if full_percentage == '100%':
                         full_percentage = colors.green | full_percentage
                     else:
                         full_percentage = colors.yellow | full_percentage
-                print(f"    {color:<30} {full_percentage}")
-            
+                print(f'    {color:<30} {full_percentage}')
+
+
 @Pets.subcommand('feed')
 class FeedPet(Pets):
     sleep_time = cli.SwitchAttr(
         ['-S', '--sleep-time'], argtype=int, default=1,
-        help=_("Time to wait between feeding each pet to avoid overloading the server"))  # noqa: Q000
+        help=_('Time to wait between feeding each pet to avoid overloading the server'))  # noqa: Q000
     maximum_food = cli.SwitchAttr(
         ['-M', '--maxmimum-food'], argtype=int, default=10,
-        help=_("Maximum amount of food to feed a pet")
+        help=_('Maximum amount of food to feed a pet')
     )
 
     def main(self, *food):
         super().main()
         if len(food) != 1:
-            self.log.error(_("error: must specify one food to feed."))  # noqa: Q000
+            self.log.error(_('error: must specify one food to feed.'))  # noqa: Q000
             return
 
         food = food[0]
@@ -478,40 +479,39 @@ class FeedPet(Pets):
             pet_specifier = pet_specifier[0].capitalize() + pet_specifier[1:]
 
         for pet in pets:
-            (pettype, color) = pet.split("-")
+            (pettype, color) = pet.split('-')
             if pet_specifier and pettype != pet_specifier:
                 continue
             if color_specifier and color != color_specifier:
                 continue
-        
-            pet_fullness = pets[pet]
+
             food_needed = self.get_food_needed(pets[pet])
             if food_needed > 0 and pet not in mounts:
                 food_amount = min(food_needed, self.maximum_food)
-                print(_(f"feeding {food_amount} {food} to {color} {pettype}"))
-                response = self.api.user.feed[pet][food].post(uri_params = {
+                print(_(f'feeding {food_amount} {food} to {color} {pettype}'))
+                response = self.api.user.feed[pet][food].post(uri_params={
                     'amount': food_amount,
                 })
-                print(_(f"   new fullness: {self.get_full_percent(response)}%"))
+                print(_(f'   new fullness: {self.get_full_percent(response)}%'))
                 time.sleep(self.sleep_time)
             else:
-                print(_(f"NOT feeding {color} {pettype}"))
+                print(_(f'NOT feeding {color} {pettype}'))
+
 
 @Pets.subcommand('hatch')
 class HatchPet(Pets):
     sleep_time = cli.SwitchAttr(
         ['-S', '--sleep-time'], argtype=int, default=1,
-        help=_("Time to wait between feeding each pet to avoid overloading the server"))  # noqa: Q000
+        help=_('Time to wait between feeding each pet to avoid overloading the server'))  # noqa: Q000
     maximum_food = cli.SwitchAttr(
         ['-M', '--maxmimum-food'], argtype=int, default=10,
-        help=_("Maximum amount of food to feed a pet")
+        help=_('Maximum amount of food to feed a pet')
     )
 
     def main(self):
         super().main()
         user = self.api.user.get()
         pets = user['items']['pets']
-        mounts = user['items']['mounts']
 
         color_specifier = self.color_specifier
         if color_specifier:
@@ -520,25 +520,25 @@ class HatchPet(Pets):
         if pet_specifier:
             pet_specifier = pet_specifier[0].capitalize() + pet_specifier[1:]
 
-        for pet in user['items']['pets']:
-            (pettype, color) = pet.split("-")
+        for pet in pets:
+            (pettype, color) = pet.split('-')
 
             if pet_specifier and pettype != pet_specifier:
                 continue
             if color_specifier and color != color_specifier:
                 continue
-        
+
             if self.is_hatchable(user, pettype, color):
-                print(_(f"hatching {color} {pettype}"))
+                print(_(f'hatching {color} {pettype}'))
                 response = self.api.user.hatch[pettype][color].post()
                 time.sleep(self.sleep_time)
             else:
-                print(_(f"NOT hatching {color} {pettype}"))
+                print(_(f'NOT hatching {color} {pettype}'))
 
 
 @HabiticaCli.subcommand('food')
 class Food(ApplicationWithApi):
-    DESCRIPTION = _("List inventory food and their quantities available")
+    DESCRIPTION = _('List inventory food and their quantities available')
 
     def main(self):
         super().main()
@@ -546,7 +546,8 @@ class Food(ApplicationWithApi):
         food_list = user['items']['food']
         food_list_keys = sorted(food_list, key=lambda x: food_list[x])
         for food in food_list_keys:
-            print(f"{food:<30}: {food_list[food]}")
+            print(f'{food:<30}: {food_list[food]}')
+
 
 @HabiticaCli.subcommand('habits')
 class Habits(TasksPrint):  # pylint: disable=missing-class-docstring

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -9,6 +9,7 @@ import logging
 import os
 import json
 import uuid
+import time
 from bisect import bisect
 from collections.abc import Mapping
 from collections import defaultdict
@@ -22,7 +23,6 @@ from .api import Habitipy
 from .util import assert_secure_file, secure_filestore
 from .util import get_translation_functions, get_translation_for
 from .util import prettify
-import time
 
 try:
     from json import JSONDecodeError  # type: ignore
@@ -367,6 +367,7 @@ class TasksPrint(ApplicationWithApi):
 
 @HabiticaCli.subcommand('pets')
 class Pets(ApplicationWithApi):
+    """Core inheritable class for dealing with actions on pets."""
     DESCRIPTION = _('List pets and their status')
     pet_specifier = cli.SwitchAttr(
         ['-P', '--pet'],
@@ -376,6 +377,7 @@ class Pets(ApplicationWithApi):
         help=_('Only show information about a particular color'))  # noqa: Q000
 
     def get_full_percent(self, amount: int):
+        """Return the percentage of "fullness" for a pet."""
         if amount == -1:
             amount = 100
         else:
@@ -383,6 +385,7 @@ class Pets(ApplicationWithApi):
         return str(amount)
 
     def get_food_needed(self, pet_fullness: int, amount_per_food: int = 5) -> int:
+        """Return the amount of food needed to feed a pet till full."""
         if pet_fullness == -1:
             return 0
         return int((50 - int(pet_fullness)) / amount_per_food)
@@ -404,7 +407,8 @@ class Pets(ApplicationWithApi):
 
 @Pets.subcommand('list')
 class ListPets(Pets):
-    def main(self):
+    """Lists all pets from the inventory."""
+    def main(self):  # pylint: disable=too-many-braches
         super().main()
         user = self.api.user.get()
         print(_('Pets:'))
@@ -452,9 +456,10 @@ class ListPets(Pets):
 
 @Pets.subcommand('feed')
 class FeedPet(Pets):
+    """Feeds a pet or pets with specified food."""
     sleep_time = cli.SwitchAttr(
         ['-S', '--sleep-time'], argtype=int, default=1,
-        help=_('Time to wait between feeding each pet to avoid overloading the server'))  # noqa: Q000
+        help=_('Time to wait between feeding each pet to avoid overloading the server'))  # pylint: disable=line-too-long
     maximum_food = cli.SwitchAttr(
         ['-M', '--maxmimum-food'], argtype=int, default=10,
         help=_('Maximum amount of food to feed a pet')
@@ -500,9 +505,10 @@ class FeedPet(Pets):
 
 @Pets.subcommand('hatch')
 class HatchPet(Pets):
+    """Hatches pets with eggs when possible."""
     sleep_time = cli.SwitchAttr(
         ['-S', '--sleep-time'], argtype=int, default=1,
-        help=_('Time to wait between feeding each pet to avoid overloading the server'))  # noqa: Q000
+        help=_('Time to wait between feeding each pet to avoid overloading the server'))  # pylint: disable=line-too-long
     maximum_food = cli.SwitchAttr(
         ['-M', '--maxmimum-food'], argtype=int, default=10,
         help=_('Maximum amount of food to feed a pet')
@@ -538,6 +544,7 @@ class HatchPet(Pets):
 
 @HabiticaCli.subcommand('food')
 class Food(ApplicationWithApi):
+    """Lists food from the inventory."""
     DESCRIPTION = _('List inventory food and their quantities available')
 
     def main(self):

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -530,7 +530,7 @@ class HatchPet(Pets):
 
             if self.is_hatchable(user, pettype, color):
                 print(_(f'hatching {color} {pettype}'))
-                response = self.api.user.hatch[pettype][color].post()
+                self.api.user.hatch[pettype][color].post()
                 time.sleep(self.sleep_time)
             else:
                 print(_(f'NOT hatching {color} {pettype}'))

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -412,11 +412,9 @@ class Pets(ApplicationWithApi):
                 pet_full_level = pet_summaries[pet][color]
                 if pet_full_level == -1:
                     full_percentage = "No Pet"
-                    if color in user["items"]["hatchingPotions"]:
-                        if pet in user["items"]["eggs"] and user["items"]["hatchingPotions"][color] > 0:
+                    if color in user["items"]["hatchingPotions"] and pet in user["items"]["eggs"]:
+                        if user["items"]["hatchingPotions"][color] > 0 and user["items"]["eggs"][pet] > 0:
                             full_percentage += " (hatchable)"
-                    elif pet in user["items"]["eggs"]:
-                        full_percentage += " (hatchable)"
                 elif pet + "-" + color in user['items']['mounts']:
                     full_percentage = "100%"
                 else:

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -408,7 +408,7 @@ class Pets(ApplicationWithApi):
 @Pets.subcommand('list')
 class ListPets(Pets):
     """Lists all pets from the inventory."""
-    def main(self):  # pylint: disable=too-many-braches
+    def main(self):  # pylint: disable=too-many-branches
         super().main()
         user = self.api.user.get()
         print(_('Pets:'))

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -366,7 +366,12 @@ class TasksPrint(ApplicationWithApi):
 @HabiticaCli.subcommand('pets')
 class Pets(ApplicationWithApi):
     DESCRIPTION = _("List pets and their status")
-    DESCRIPTION = _("Show HP, XP, GP, and more")  # noqa: Q000
+    pet_specifier = cli.SwitchAttr(
+        ['-P', '--pet'],
+        help=_("Only show information about a particular pet"))  # noqa: Q000
+    color_specifier = cli.SwitchAttr(
+        ['-C', '--color'],
+        help=_("Only show information about a particular color"))  # noqa: Q000
 
     def main(self):
         super().main()
@@ -382,8 +387,17 @@ class Pets(ApplicationWithApi):
                 pet_summaries[pettype][color] = -1
 
         for pet in pet_summaries:
-            print(f"  {pet}:")
+            if self.pet_specifier and pet != self.pet_specifier:
+                continue
+            pet_printed = False
             for color in pet_summaries[pet]:
+                if self.color_specifier and color != self.color_specifier:
+                    continue
+
+                if not pet_printed:
+                    print(f"  {pet}:")
+                    pet_printed = True
+
                 full = pet_summaries[pet][color]
                 amount_needed = int((50 - full)/5)
                 if amount_needed == 0 or full == -1:

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -11,6 +11,7 @@ import json
 import uuid
 from bisect import bisect
 from collections.abc import Mapping
+from collections import defaultdict
 from itertools import chain
 from textwrap import dedent
 from typing import List, Union, Dict, Any  # pylint: disable=unused-import
@@ -362,6 +363,33 @@ class TasksPrint(ApplicationWithApi):
             res = i + prettify(self.domain_format(task))
             print(res)
 
+@HabiticaCli.subcommand('pets')
+class Pets(ApplicationWithApi):
+    DESCRIPTION = _("List pets and their status")
+    DESCRIPTION = _("Show HP, XP, GP, and more")  # noqa: Q000
+
+    def main(self):
+        super().main()
+        user = self.api.user.get()
+        print("Pets:")
+
+        # split pets into type and color
+        pet_summaries = defaultdict(dict)
+        for pet in user['items']['pets']:
+            (pettype, color) = pet.split("-")
+            pet_summaries[pettype][color] = user['items']['pets'][pet]
+            if pet in user['items']['mounts']:
+                pet_summaries[pettype][color] = -1
+
+        for pet in pet_summaries:
+            print(f"  {pet}:")
+            for color in pet_summaries[pet]:
+                full = pet_summaries[pet][color]
+                amount_needed = int((50 - full)/5)
+                if amount_needed == 0 or full == -1:
+                    amount_needed = "None"
+                print(f"    {color:<30} food_needed={amount_needed}")
+            
 
 @HabiticaCli.subcommand('habits')
 class Habits(TasksPrint):  # pylint: disable=missing-class-docstring

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -391,7 +391,7 @@ class Pets(ApplicationWithApi):
         return int((50 - int(pet_fullness)) / amount_per_food)
 
     def is_hatchable(self, user: list, pet: str, color: str) -> bool:
-        "Return true when a pat of a particular type and color can be hatched."
+        """Return true when a pat of a particular type and color can be hatched."""
         combined = pet + '-' + color
 
         # check if pet exists or name is wrong

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -390,7 +390,7 @@ class Pets(ApplicationWithApi):
             return 0
         return int((50 - int(pet_fullness)) / amount_per_food)
 
-    def is_hatchable(self, user: list, pet: str, color: str) -> bool:
+    def is_hatchable(self, user: dict, pet: str, color: str) -> bool:
         """Return true when a pat of a particular type and color can be hatched."""
         combined = pet + '-' + color
 

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -409,6 +409,13 @@ class ListPets(Pets):
         user = self.api.user.get()
         print(_("Pets:"))
 
+        color_specifier = self.color_specifier
+        if color_specifier:
+            color_specifier = color_specifier[0].capitalize() + color_specifier[1:]
+        pet_specifier = self.pet_specifier
+        if pet_specifier:
+            pet_specifier = pet_specifier[0].capitalize() + pet_specifier[1:]
+
         # split pets into type and color
         pet_summaries = defaultdict(dict)
         for pet in user['items']['pets']:
@@ -416,11 +423,11 @@ class ListPets(Pets):
             pet_summaries[pettype][color] = user['items']['pets'][pet]
 
         for pet in pet_summaries:
-            if self.pet_specifier and pet != self.pet_specifier:
+            if pet_specifier and pet != pet_specifier:
                 continue
             pet_printed = False
             for color in pet_summaries[pet]:
-                if self.color_specifier and color != self.color_specifier:
+                if color_specifier and color != color_specifier:
                     continue
 
                 if not pet_printed:
@@ -431,11 +438,15 @@ class ListPets(Pets):
                 if pet_full_level == -1:
                     full_percentage = colors.red | _("No Pet")
                     if self.is_hatchable(user, pet, color):
-                        full_percentage += " " + colors.green | _("(hatchable)")
+                        full_percentage += " " + (colors.green | _("(hatchable)"))
                 elif pet + "-" + color in user['items']['mounts']:
                     full_percentage = colors.green | "100%"
                 else:
                     full_percentage = self.get_full_percent(pet_full_level) + "%"
+                    if full_percentage == "100%":
+                        full_percentage = colors.green | full_percentage
+                    else:
+                        full_percentage = colors.yellow | full_percentage
                 print(f"    {color:<30} {full_percentage}")
             
 @Pets.subcommand('feed')
@@ -459,11 +470,18 @@ class FeedPet(Pets):
         pets = user['items']['pets']
         mounts = user['items']['mounts']
 
+        color_specifier = self.color_specifier
+        if color_specifier:
+            color_specifier = color_specifier[0].capitalize() + color_specifier[1:]
+        pet_specifier = self.pet_specifier
+        if pet_specifier:
+            pet_specifier = pet_specifier[0].capitalize() + pet_specifier[1:]
+
         for pet in pets:
             (pettype, color) = pet.split("-")
-            if self.pet_specifier and pettype != self.pet_specifier:
+            if pet_specifier and pettype != pet_specifier:
                 continue
-            if self.color_specifier and color != self.color_specifier:
+            if color_specifier and color != color_specifier:
                 continue
         
             pet_fullness = pets[pet]
@@ -495,12 +513,19 @@ class HatchPet(Pets):
         pets = user['items']['pets']
         mounts = user['items']['mounts']
 
+        color_specifier = self.color_specifier
+        if color_specifier:
+            color_specifier = color_specifier[0].capitalize() + color_specifier[1:]
+        pet_specifier = self.pet_specifier
+        if pet_specifier:
+            pet_specifier = pet_specifier[0].capitalize() + pet_specifier[1:]
+
         for pet in user['items']['pets']:
             (pettype, color) = pet.split("-")
 
-            if self.pet_specifier and pettype != self.pet_specifier:
+            if pet_specifier and pettype != pet_specifier:
                 continue
-            if self.color_specifier and color != self.color_specifier:
+            if color_specifier and color != color_specifier:
                 continue
         
             if self.is_hatchable(user, pettype, color):

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -22,6 +22,7 @@ from .api import Habitipy
 from .util import assert_secure_file, secure_filestore
 from .util import get_translation_functions, get_translation_for
 from .util import prettify
+import time
 
 try:
     from json import JSONDecodeError  # type: ignore
@@ -399,11 +400,62 @@ class Pets(ApplicationWithApi):
                     pet_printed = True
 
                 full = pet_summaries[pet][color]
-                amount_needed = int((50 - full)/5)
-                if amount_needed == 0 or full == -1:
-                    amount_needed = "None"
-                print(f"    {color:<30} food_needed={amount_needed}")
+                food_needed = int((50 - full)/5)
+                if food_needed == 0 or full == -1:
+                    food_needed = "None"
+                print(f"    {color:<30} food_needed={food_needed}")
             
+@Pets.subcommand('feed')
+class FeedPet(ApplicationWithApi):
+    pet_specifier = cli.SwitchAttr(
+        ['-P', '--pet'],
+        help=_("Only show information about a particular pet"))  # noqa: Q000
+    color_specifier = cli.SwitchAttr(
+        ['-C', '--color'],
+        help=_("Only show information about a particular color"))  # noqa: Q000
+    def main(self, *food):
+        super().main()
+        if len(food) != 1:
+            self.log.error(_("error: must specify one food to feed."))  # noqa: Q000
+            return
+
+        food = food[0]
+        user = self.api.user.get()
+        pets = user['items']['pets']
+        mounts = user['items']['mounts']
+        sleep_time = 1
+
+        for pet in user['items']['pets']:
+            (pettype, color) = pet.split("-")
+            if self.pet_specifier and pettype != self.pet_specifier:
+                continue
+            if self.color_specifier and color != self.color_specifier:
+                continue
+        
+            pet_fullness = pets[pet]
+            food_needed = int((50 - pet_fullness)/5)
+            if food_needed > 0 and pet_fullness != -1 and pet not in mounts:
+                print(f"feeding {food_needed} {food} to {color} {pettype}")
+                response = self.api.user.feed[pet][food].post(uri_params = {
+                    'amount': food_needed
+                })
+                print(f"   response:{response}")
+                time.sleep(sleep_time)
+            else:
+                print(f"NOT feeding {color} {pettype}")
+
+
+@HabiticaCli.subcommand('food')
+class Food(ApplicationWithApi):
+    DESCRIPTION = _("List inventory food and their quantities available")
+
+    def main(self):
+        super().main()
+        user = self.api.user.get()
+        food_list = user['items']['food']
+        food_list_keys = sorted(food_list, key=lambda x: food_list[x])
+        for food in food_list_keys:
+            print(f"{food:<30}: {food_list[food]}")
 
 @HabiticaCli.subcommand('habits')
 class Habits(TasksPrint):  # pylint: disable=missing-class-docstring


### PR DESCRIPTION
I added a slew of new commands to help manage pets.  They're certainly not perfect and certainly others may want to alter output, etc, but as is this patch implements:

`pets list`: list pets in your inventory
`food`: lists food in your inventory
`pets feed FOOD` feed FOOD to pets
`pets hatch` hatches pets using available eggs and potions

These all take -P and -C flags to limit actions to specific pet types or colors.