### PR TITLE
add support for checklist items in todos

### DIFF
--- a/habitipy/api.py
+++ b/habitipy/api.py
@@ -222,7 +222,8 @@ class Habitipy:
     def _make_headers(self):
         headers = {
             'x-api-user': self._conf['login'],
-            'x-api-key': self._conf['password']
+            'x-api-key': self._conf['password'],
+            'x-client': 'python-habitipy',
         } if self._conf else {}
         headers.update({'content-type': API_CONTENT_TYPE})
         return headers

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -1071,6 +1071,7 @@ class TodosAdd(ApplicationWithApi):  # pylint: disable=missing-class-docstring
             checklist.append({'text':item, 'completed':False})
         self.api.tasks.user.post(type='todo', text=todo_str, priority=self.priority, checklist=checklist)
         res = _("Added todo '{}' with priority {}").format(todo_str, self.priority)  # noqa: Q000
+        print(prettify(res))
         ToDos.invoke(config_filename=self.config_filename)
         return 0
 

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -1057,7 +1057,7 @@ class TodosAdd(ApplicationWithApi):  # pylint: disable=missing-class-docstring
         cli.Set('0.1', '1', '1.5', '2'), default='1',
         help=_("Priority (complexity) of a todo"))  # noqa: Q000
     checks = cli.SwitchAttr(
-        ['-l', '--check'], default='', list=True,
+        ['-l', '--check'], list=True,
         help=_("Add <check> to checklist for a todo"))
 
     def main(self, *todo: str):

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -792,8 +792,7 @@ class ToDos(TasksPrint):  # pylint: disable=missing-class-docstring
         if len(todo['checklist']) > 0:
             for item in todo['checklist']:
                 if not item['completed']: checklist_full = checklist_full + "\n       - " + item['text']
-        res = _("{1}{0}{text}{2}").format(check, score, checklist, **todo)  # noqa: Q000
-        res = res + checklist_full
+        res = _("{1}{0}{text}{2}{3}").format(check, score, checklist, checklist_full, **todo)  # noqa: Q000
         return res
 
 
@@ -1054,9 +1053,9 @@ class TodosAdd(ApplicationWithApi):  # pylint: disable=missing-class-docstring
         ['-p', '--priority'],
         cli.Set('0.1', '1', '1.5', '2'), default='1',
         help=_("Priority (complexity) of a todo"))  # noqa: Q000
-    checklist = cli.SwitchAttr(
+    checks = cli.SwitchAttr(
         ['-l', '--check'], default='', list=True,
-        help=_("checklist item"))
+        help=_("Add <check> to checklist for a todo"))
 
     def main(self, *todo: str):
         todo_str = ' '.join(todo)
@@ -1064,11 +1063,11 @@ class TodosAdd(ApplicationWithApi):  # pylint: disable=missing-class-docstring
             self.log.error(_("Empty todo text!"))  # noqa: Q000
             return 1
         super().main()
-        result = self.api.tasks.user.post(type='todo', text=todo_str, priority=self.priority)
+        checklist = list()
+        for item in self.checks:
+            checklist.append({'text':item, 'completed':False})
+        self.api.tasks.user.post(type='todo', text=todo_str, priority=self.priority, checklist=checklist)
         res = _("Added todo '{}' with priority {}").format(todo_str, self.priority)  # noqa: Q000
-        print(prettify(res))
-        id = result['id']
-        for item in self.checklist: self.api.tasks[id].checklist.post(text=item)
         ToDos.invoke(config_filename=self.config_filename)
         return 0
 

--- a/habitipy/cli.py
+++ b/habitipy/cli.py
@@ -778,6 +778,9 @@ class Dailys(TasksPrint):  # pylint: disable=missing-class-docstring
 class ToDos(TasksPrint):  # pylint: disable=missing-class-docstring
     DESCRIPTION = _("List, comlete, add or delete todo tasks")  # noqa: Q000
     domain = 'todos'
+    full = cli.Flag(
+        ['-f', '--full'],
+        help=_("Print todos with checklist items."))  # noqa: Q000
     def domain_format(self, todo):  # pylint: disable=arguments-renamed
         score = ScoreInfo(self.config['show_style'], todo['value'])
         check = CHECK if todo['completed'] else UNCHECK
@@ -789,7 +792,7 @@ class ToDos(TasksPrint):  # pylint: disable=missing-class-docstring
                 len(todo['checklist'])
             ) if todo['checklist'] else ''
         checklist_full = ''
-        if len(todo['checklist']) > 0:
+        if self.full and len(todo['checklist']) > 0:
             for item in todo['checklist']:
                 if not item['completed']: checklist_full = checklist_full + "\n       - " + item['text']
         res = _("{1}{0}{text}{2}{3}").format(check, score, checklist, checklist_full, **todo)  # noqa: Q000


### PR DESCRIPTION
I am trying to add checklist items under todos.

` habitipy todos add todo item --check check1 --check check2`

and I had also updated todo list to show checks.

```
$ habitipy todos add todo item --check check1 --check check2
Added todo 'todo item' with priority 1
 1. ▄✖ todo item 0/2
```

list will print checklist items only with --full defined
```
$ habitipy todos --full
 1. ▄✖ test 0/2
       - 1
       - 2

```