### PR TITLE
add an x-client header now required by habitica

### DIFF
--- a/habitipy/api.py
+++ b/habitipy/api.py
@@ -222,7 +222,8 @@ class Habitipy:
     def _make_headers(self):
         headers = {
             'x-api-user': self._conf['login'],
-            'x-api-key': self._conf['password']
+            'x-api-key': self._conf['password'],
+            'x-client': 'python-habitipy',
         } if self._conf else {}
         headers.update({'content-type': API_CONTENT_TYPE})
         return headers


### PR DESCRIPTION
The habitica side changed and new requires a x-client header, so this patch adds one to fix bug #203 .